### PR TITLE
async.done not being called if there are no input files.

### DIFF
--- a/tasks/closurecompiler.js
+++ b/tasks/closurecompiler.js
@@ -23,25 +23,30 @@
 'use strict';
 
 module.exports = function (grunt) {
-    
+
     grunt.registerMultiTask('closurecompiler', 'Compile through ClosureCompiler.js', function () {
         var options = this.options({
             "compilation_level": "SIMPLE_OPTIMIZATIONS"
         });
-        
+
         var ClosureCompiler = require("closurecompiler");
         var done = this.async();
         var running = 0;
         var to = null;
-        
+
+        if (this.files.length === 0) {
+            done();
+            return;
+        }
+
         this.files.forEach(function(file) {
             if (to) { clearTimeout(to); to = null; }
-            
+
             var sources = file.src;
             var dest = file.dest;
-            
+
             grunt.log.subhead("Compiling "+file.src+" -> "+dest);
-            
+
             if (sources.length == 0 || !dest) {
                 grunt.log.error("Please provide at least one source and exactly one destination file.");
                 to = setTimeout(maybeFinish, 1000);
@@ -62,7 +67,7 @@ module.exports = function (grunt) {
                 });
             }
         });
-        
+
         var finished = false;
         function maybeFinish() {
             if (running == 0) {


### PR DESCRIPTION
I've added a call to async.done if the length of files is 0. This can happen in the case where there is a filter on the files based on modification date, e.g.

files:[{ expand:true,
          cwd:"js/",
          dest:"js.min/",
          src:["*_/_.js"],
          filter: function() {
              /\* return true here if source file is newer than the output file */
          }
      }]
