### PR TITLE
Updating ClosureCompiler to support option banners.

### DIFF
--- a/tasks/closurecompiler.js
+++ b/tasks/closurecompiler.js
@@ -30,6 +30,12 @@ module.exports = function (grunt) {
             "compilation_level": "SIMPLE_OPTIMIZATIONS",
             "max_processes": Number.MAX_VALUE
         });
+        var banner = "";
+
+        if (options.banner !== undefined) {
+            banner = options.banner+"\n";
+            delete options.banner;
+        }
 
         var maxProcesses = options.max_processes;
         delete options.max_processes;
@@ -66,7 +72,7 @@ module.exports = function (grunt) {
                     running++;
                     ClosureCompiler.compile(sources, options, function(error, result) {
                         if (result) {
-                            grunt.file.write(dest, result=""+result);
+                            grunt.file.write(dest, result=banner+result);
                             if (error) {
                                 grunt.log.warn(""+error);
                             }

--- a/tasks/closurecompiler.js
+++ b/tasks/closurecompiler.js
@@ -28,8 +28,7 @@ module.exports = function (grunt) {
 
         var options = this.options({
             "compilation_level": "SIMPLE_OPTIMIZATIONS",
-            "max_processes": Number.MAX_VALUE,
-            "banner": ""
+            "max_processes": Number.MAX_VALUE
         });
         var banner = "";
 

--- a/tasks/closurecompiler.js
+++ b/tasks/closurecompiler.js
@@ -28,8 +28,15 @@ module.exports = function (grunt) {
 
         var options = this.options({
             "compilation_level": "SIMPLE_OPTIMIZATIONS",
-            "max_processes": Number.MAX_VALUE
+            "max_processes": Number.MAX_VALUE,
+            "banner": ""
         });
+        var banner = "";
+
+        if (options.banner !== undefined) {
+            banner = options.banner+"\n";
+            delete options.banner;
+        }
 
         var maxProcesses = options.max_processes;
         delete options.max_processes;
@@ -66,7 +73,7 @@ module.exports = function (grunt) {
                     running++;
                     ClosureCompiler.compile(sources, options, function(error, result) {
                         if (result) {
-                            grunt.file.write(dest, result=""+result);
+                            grunt.file.write(dest, result=banner+result);
                             if (error) {
                                 grunt.log.warn(""+error);
                             }


### PR DESCRIPTION
When compressing production code it is often important (or legally required) to add in a copyright or attribution notice. This allows one to be easily set in a compatible way with many other grunt plugins - using a banner variable in the options.

This feature was very important for my companies production code, and also for personal projects - so I patched it in.
